### PR TITLE
Fetch logs for all applications within organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,19 +26,19 @@ docker-compose up
 # configuration
 
 ```
-input { 
-    cloudhub { 
-        domain => "my-application" 
-        username => "Bob" 
-        password => "secret"
-        interval => 300
-        startTime => 0
-        proxy_host => "squid"
-        proxy_port => 3128
-        proxy_username => "user"
-        proxy_password => "secret"
-    } 
-} 
+input {
+	cloudhub { 
+		type => "CloudHub"
+        organization_id => "uuid of your company" 
+        username => "anypoint-user" 
+        password => "anypoint-password"
+        interval => 30
+        proxy_host => "proxy-host"
+        proxy_port => 8080
+        proxy_username => "proxy-user"
+        proxy_password => "proxy-password"
+	}
+}
 
 output { 
     stdout {} 

--- a/lib/logstash/inputs/cloudhub.rb
+++ b/lib/logstash/inputs/cloudhub.rb
@@ -1,68 +1,49 @@
-# encoding: utf-8
+# logstash-input-cloudhub
+plugin for logstash, which pulls logs from a application deployed to [Cloudhub](anypoint.mulesoft.com/cloudhub).
 
-require_relative 'cloudhub_api'
-require_relative 'sincedb'
+# try it out
+`Dockerfile` and `docker-compose.yml` contains everything you need to try it out, assumed you already have docker-compose installed and a Docker instance running.
 
-require "logstash/inputs/base"
-require "logstash/namespace"
-require "stud/interval"
-require "fileutils"
-require "socket"
+## build the plugin from source.
+```
+# gem can be used instead of jgem
+jgem build logstash-input-cloudhub.gemspec
+```
 
-class LogStash::Inputs::Cloudhub < LogStash::Inputs::Base
-  config_name "cloudhub"
+## setup a container with logstash 2.4 and install the plugin
+```
+docker-compose build
+```
 
-  config :domain, :validate => :string
-  config :username, :validate => :string
-  config :password, :validate => :string
-  config :interval, :validate => :number, :default => 300
-  config :environment_id, :validate => :string, :default => ""
-  config :startTime, :validate => :number, :default => 0
+## run the container with logstash and the plugin.
+```
+export CLOUDHUB_DOMAIN=<application>
+export CLOUDHUB_USERNAME=<username>
+export CLOUDHUB_PASSWORD=<password> 
+docker-compose up
+```
 
-  config :proxy_host, :validate => :string
-  config :proxy_port, :validate => :number
-  config :proxy_username, :validate => :string
-  config :proxy_password, :validate => :string
+# configuration
 
-  default :codec, "plain"
+```
+input { 
+    cloudhub { 
+        domain => "my-application" 
+        username => "Bob" 
+        password => "secret"
+        interval => 300
+        startTime => 0
+        proxy_host => "squid"
+        proxy_port => 3128
+        proxy_username => "user"
+        proxy_password => "secret"
+    } 
+} 
 
-  public
-  def register
-    @host = Socket.gethostname
-    @sincedb = SinceDB.new
+output { 
+    stdout {} 
+}
+```
 
-    startTimeSinceDB = @sincedb.read @domain
-    if startTimeSinceDB > @startTime
-      @startTime = startTimeSinceDB
-    end
-  end
-
-  def run(queue)
-    api = CloudhubAPI.new @domain, @username, @password, @proxy_host, @proxy_port, @proxy_username, @proxy_password
-
-    while !stop?
-      loop do
-        logs = api.logs(@startTime, @environment_id)
-        break if logs.empty?
-
-        for log in logs do
-          event = LogStash::Event.new(
-            'message' => JSON.generate(log),
-            'host' => @host
-          )
-
-          decorate(event)
-          queue << event
-        end
-
-        @startTime = logs[-1]['event']['timestamp'] + 1
-      end
-
-      @sincedb.write @domain, @startTime
-      Stud.stoppable_sleep (@interval) { stop? }
-    end
-  end
-
-  def stop
-  end
-end
+# further information
+[Cloudhub Enhanced Logging API 1.0.0](https://anypoint.mulesoft.com/apiplatform/anypoint-platform/#/portals/organizations/68ef9520-24e9-4cf2-b2f5-620025690913/apis/34348/versions/35742/pages/49591)

--- a/lib/logstash/inputs/cloudhub.rb
+++ b/lib/logstash/inputs/cloudhub.rb
@@ -9,19 +9,40 @@ require "stud/interval"
 require "fileutils"
 require "socket"
 
+# This input plugin reads log messages from the Anypoint REST API.
+# You don't need to configure your environments/applications, the
+# plugin will fetch all.
 class LogStash::Inputs::Cloudhub < LogStash::Inputs::Base
   config_name "cloudhub"
 
-  config :domain, :validate => :string
+  # Organization ID of the Anypoint company account
+  config :organization_id, :validate => :string
+  
+  # Anypoint user name
   config :username, :validate => :string
+  
+  # Anypoint password
   config :password, :validate => :string
+  
+  # Interval (in seconds) between two log fetches.
+  # (End of previous fetch to start of next fetch)
+  # Default value: 300
   config :interval, :validate => :number, :default => 300
-  config :environment_id, :validate => :string, :default => ""
-  config :startTime, :validate => :number, :default => 0
+  
+  # How many events should be fetched in one REST call?
+  # Default: 100
+  config :events_per_call, :validate => :number, :default => 100
 
+  # Host name of web proxy
   config :proxy_host, :validate => :string
+  
+  # Port of web proxy
   config :proxy_port, :validate => :number
+  
+  # User name of web proxy
   config :proxy_username, :validate => :string
+  
+  # Password of web proxy
   config :proxy_password, :validate => :string
 
   default :codec, "plain"
@@ -30,39 +51,73 @@ class LogStash::Inputs::Cloudhub < LogStash::Inputs::Base
   def register
     @host = Socket.gethostname
     @sincedb = SinceDB.new
-
-    startTimeSinceDB = @sincedb.read @domain
-    if startTimeSinceDB > @startTime
-      @startTime = startTimeSinceDB
-    end
   end
 
   def run(queue)
-    api = CloudhubAPI.new @domain, @username, @password, @proxy_host, @proxy_port, @proxy_username, @proxy_password
+    api = CloudhubAPI.new @logger, @organization_id, @username, @password, @events_per_call, @proxy_host, @proxy_port, @proxy_username, @proxy_password
 
     while !stop?
-      loop do
-        logs = api.logs(@startTime, @environment_id)
-        break if logs.empty?
-
-        for log in logs do
-          event = LogStash::Event.new(
-            'message' => JSON.generate(log),
-            'host' => @host
-          )
-
-          decorate(event)
-          queue << event
+        
+      # get the token once per main loop (more efficient than fetching it for each API call)
+      token = api.token()
+        
+      environments = api.environments(token)
+      environments.each do |environment|
+        applications = api.apps(environment, token)
+        applications.each do |application|
+          application_name = application['domain']
+          begin
+            @logger.info("Fetching logs for " + application_name)
+            
+            first_start_time = @sincedb.read application_name
+            start_time = first_start_time
+            while !stop?
+              logs = api.logs(start_time, environment['id'], application_name, token)
+              break if logs.empty?
+              
+              start_time = logs[-1]['event']['timestamp'] + 1
+              push_logs logs, environment['name'], application_name, queue
+            end
+          rescue => exception
+            puts exception.backtrace
+          end
+          if (start_time > first_start_time)
+            @sincedb.write application_name, start_time
+          end
+          break if stop?
         end
-
-        @startTime = logs[-1]['event']['timestamp'] + 1
+        break if stop?
       end
+      Stud.stoppable_sleep(@interval) { stop? }
+    end
+  end
 
-      @sincedb.write @domain, @startTime
-      Stud.stoppable_sleep (@interval) { stop? }
+  def push_logs logs, environment, domain, queue
+    for log in logs do
+      event = log['event']
+      log_event = LogStash::Event.new(
+        'host' => @host,
+        'environment' => environment,
+        'application' => domain,
+
+        'deploymentId' => log['deploymentId'],
+        'instanceId' => log['instanceId'],
+        'recordId' => log['recordId'],
+
+        'line' => log['line'],
+        'loggerName' => event['loggerName'],
+        'threadName' => event['threadName'],
+        'priority' => event['priority'],
+        'timestamp' => event['timestamp'],
+        'message' => event['message']
+      )
+      decorate(log_event)
+      queue << log_event
     end
   end
 
   def stop
+    @logger.info("Stopping CloudHub plugin")
   end
+  
 end

--- a/lib/logstash/inputs/cloudhub_api.rb
+++ b/lib/logstash/inputs/cloudhub_api.rb
@@ -1,49 +1,100 @@
-# logstash-input-cloudhub
-plugin for logstash, which pulls logs from a application deployed to [Cloudhub](anypoint.mulesoft.com/cloudhub).
+# encoding: utf-8
 
-# try it out
-`Dockerfile` and `docker-compose.yml` contains everything you need to try it out, assumed you already have docker-compose installed and a Docker instance running.
+require "net/http"
+require "json"
 
-## build the plugin from source.
-```
-# gem can be used instead of jgem
-jgem build logstash-input-cloudhub.gemspec
-```
+class CloudhubAPI
+  def initialize logger, organization_id, username, password, events_per_call, proxy_host=nil, proxy_port=nil, proxy_username=nil, proxy_password=nil
+    @logger = logger
+    @organization_id = organization_id
+    @username = username
+    @password = password
+    @events_per_call = events_per_call
+    @proxy_host=proxy_host
+    @proxy_port=proxy_port
+    @proxy_username=proxy_username
+    @proxy_password=proxy_password
+  end
 
-## setup a container with logstash 2.4 and install the plugin
-```
-docker-compose build
-```
+  def token
+    uri = URI.parse('https://anypoint.mulesoft.com/accounts/login')
 
-## run the container with logstash and the plugin.
-```
-export CLOUDHUB_DOMAIN=<application>
-export CLOUDHUB_USERNAME=<username>
-export CLOUDHUB_PASSWORD=<password> 
-docker-compose up
-```
+    client = Net::HTTP.new(uri.host, uri.port, @proxy_host, @proxy_port, @proxy_username, @proxy_password)
+    client.use_ssl = true
 
-# configuration
+    request = Net::HTTP::Post.new(uri.request_uri)
+    request.body = URI.encode_www_form({ 
+      "username" => @username, 
+      "password" => @password 
+    })
 
-```
-input { 
-    cloudhub { 
-        domain => "my-application" 
-        username => "Bob" 
-        password => "secret"
-        interval => 300
-        startTime => 0
-        proxy_host => "squid"
-        proxy_port => 3128
-        proxy_username => "user"
-        proxy_password => "secret"
-    } 
-} 
+    response = client.request(request)
+    return JSON.parse(response.body)['access_token']
+  end
 
-output { 
-    stdout {} 
-}
-```
+  # Returns an array of hashes, sample hash:
+  # {"id"=>"...", "name"=>"prod", "organizationId"=>"...", "isProduction"=>true}
+  def environments cached_token=token
+    uri = URI.parse("https://anypoint.mulesoft.com/accounts/api/organizations/#{@organization_id}")
+    
+    client = Net::HTTP.new(uri.host, uri.port, @proxy_host, @proxy_port, @proxy_username, @proxy_password)
+    client.use_ssl = true
+    
+    request = Net::HTTP::Get.new(uri.request_uri)
+    request.add_field("Authorization", "Bearer #{cached_token}")
+    response = client.request(request)
+    
+    body = JSON.parse(response.body)
+    
+    return body['environments']
+  end
+  
+  # Returns an array of hashes, for us is interesting:
+  # { "domain"=>"my_name", "fullDomain"=>"my_name.eu.cloudhub.io", ... }
+  def apps environment, cached_token=token
+    uri = URI.parse("https://anypoint.mulesoft.com/cloudhub/api/v2/applications")
+    client = Net::HTTP.new(uri.host, uri.port, @proxy_host, @proxy_port, @proxy_username, @proxy_password)
+    client.use_ssl = true
 
-# further information
-[Cloudhub Enhanced Logging API 1.0.0](https://anypoint.mulesoft.com/apiplatform/anypoint-platform/#/portals/organizations/68ef9520-24e9-4cf2-b2f5-620025690913/apis/34348/versions/35742/pages/49591)
+    request = Net::HTTP::Get.new(uri.request_uri)
+    request.add_field("Authorization", "Bearer #{cached_token}")
+    request.add_field("X-ANYPNT-ENV-ID", environment['id'])
+    
+    response = client.request(request)
+    
+    return JSON.parse(response.body)
+  end
+  
+  def logs startTime, environment_id, application, cached_token=token
+    uri = URI.parse("https://anypoint.mulesoft.com/cloudhub/api/v2/applications/#{application}/logs")
+
+    client = Net::HTTP.new(uri.host, uri.port, @proxy_host, @proxy_port, @proxy_username, @proxy_password)
+    client.use_ssl = true
+
+    request = Net::HTTP::Post.new(uri.request_uri)
+    request.add_field("Authorization", "Bearer #{cached_token}")
+    request.content_type = 'application/json'
+    request.body = JSON.generate({
+      :startTime => startTime,
+      :endTime => java.lang.Long::MAX_VALUE,
+      :limit => @events_per_call, 
+      :descending => false
+    })
+    request.add_field("X-ANYPNT-ENV-ID", environment_id)
+    retries = 10
+    while retries > 0
+      response = client.request(request)
+      begin
+        parsed_logs = JSON.parse(response.body)
+        return parsed_logs
+      rescue
+        retries -= 1
+        if (retries == 0)
+          @logger.error("Can't parse logs: " + response.body)
+        end
+        Stud.stoppable_sleep(5)
+      end
+    end
+    return []
+  end
+end

--- a/lib/logstash/inputs/cloudhub_api.rb
+++ b/lib/logstash/inputs/cloudhub_api.rb
@@ -1,56 +1,49 @@
-# encoding: utf-8
+# logstash-input-cloudhub
+plugin for logstash, which pulls logs from a application deployed to [Cloudhub](anypoint.mulesoft.com/cloudhub).
 
-require "net/http"
-require "json"
+# try it out
+`Dockerfile` and `docker-compose.yml` contains everything you need to try it out, assumed you already have docker-compose installed and a Docker instance running.
 
-class CloudhubAPI
-  def initialize domain, username, password, proxy_host=nil, proxy_port=nil, proxy_username=nil, proxy_password=nil
-    @domain = domain
-    @username = username
-    @password = password
-    @proxy_host=proxy_host
-    @proxy_port=proxy_port
-    @proxy_username=proxy_username
-    @proxy_password=proxy_password
-  end
+## build the plugin from source.
+```
+# gem can be used instead of jgem
+jgem build logstash-input-cloudhub.gemspec
+```
 
-  def token
-    uri = URI.parse('https://anypoint.mulesoft.com/accounts/login')
+## setup a container with logstash 2.4 and install the plugin
+```
+docker-compose build
+```
 
-    client = Net::HTTP.new(uri.host, uri.port, @proxy_host, @proxy_port, @proxy_username, @proxy_password)
-    client.use_ssl = true
+## run the container with logstash and the plugin.
+```
+export CLOUDHUB_DOMAIN=<application>
+export CLOUDHUB_USERNAME=<username>
+export CLOUDHUB_PASSWORD=<password> 
+docker-compose up
+```
 
-    request = Net::HTTP::Post.new(uri.request_uri)
-    request.body = URI.encode_www_form({ 
-      "username" => @username, 
-      "password" => @password 
-    })
+# configuration
 
-    response = client.request(request)
-    return JSON.parse(response.body)['access_token']
-  end
+```
+input { 
+    cloudhub { 
+        domain => "my-application" 
+        username => "Bob" 
+        password => "secret"
+        interval => 300
+        startTime => 0
+        proxy_host => "squid"
+        proxy_port => 3128
+        proxy_username => "user"
+        proxy_password => "secret"
+    } 
+} 
 
-  def logs startTime, environment_id=nil
-    uri = URI.parse("https://anypoint.mulesoft.com/cloudhub/api/v2/applications/#{@domain}/logs")
+output { 
+    stdout {} 
+}
+```
 
-    client = Net::HTTP.new(uri.host, uri.port, @proxy_host, @proxy_port, @proxy_username, @proxy_password)
-    client.use_ssl = true
-
-    request = Net::HTTP::Post.new(uri.request_uri)
-    request.add_field("Authorization", "Bearer #{token}")
-    request.content_type = 'application/json'
-    request.body = JSON.generate({
-      :startTime => startTime,
-      :endTime => java.lang.Long::MAX_VALUE,
-      :limit => 100,
-      :descending => false
-    })
-
-    if environment_id.to_s.strip.length > 0
-      request.add_field("X-ANYPNT-ENV-ID", environment_id)
-    end
-
-    response = client.request(request)
-    return JSON.parse(response.body)
-  end
-end
+# further information
+[Cloudhub Enhanced Logging API 1.0.0](https://anypoint.mulesoft.com/apiplatform/anypoint-platform/#/portals/organizations/68ef9520-24e9-4cf2-b2f5-620025690913/apis/34348/versions/35742/pages/49591)

--- a/lib/logstash/inputs/sincedb.rb
+++ b/lib/logstash/inputs/sincedb.rb
@@ -1,36 +1,43 @@
-require "digest/md5"
+# encoding: utf-8
 
 class SinceDB
-    def initialize folder=nil, file_prefix='sincedb_'
-        @folder = folder
-        if @folder.to_s.strip.length == 0
-            @folder = File.join(Dir.home, ".logstash-input-cloudhub")
-        end
-
-        @file_prefix = file_prefix
+  def initialize folder=nil, file_prefix='sincedb-'
+    
+    @folder = folder
+    if @folder.to_s.strip.length == 0
+      @folder = ::File.join(LogStash::SETTINGS.get('path.data'), 'plugins', 'cloudhub')
+      FileUtils::mkdir_p(@folder)
     end
-
-    def write domain, content
-        FileUtils::mkdir_p @folder
-
-        file_path = construct_file_path(domain)
-        File.open(file_path, "w") { |file| file.write(content) }
+  
+    @file_prefix = file_prefix
+  end
+  
+  def write domain, content
+    file_path = construct_file_path(domain)
+    File.open(file_path, "w") { |file| file.write(content) }
+  end
+  
+  def read domain
+    result = 0
+    file_path = construct_file_path(domain)
+    if File.exists? file_path
+        result = File.open(file_path, 'r') { 
+            |file| file.read.to_i 
+        }
     end
-
-    def read domain
-        result = 0
-        file_path = construct_file_path(domain)
-        if File.exists? file_path
-            result = File.open(file_path, 'r') { 
-                |file| file.read.to_i 
-            }
-        end
-
-        return result
-    end
-
-    private
-    def construct_file_path domain
-        File.join(@folder, @file_prefix + Digest::MD5.hexdigest(domain))
-    end
+  
+    return result
+  end
+  
+  private
+  def construct_file_path domain
+    File.join(@folder, @file_prefix + sanitize(domain))
+  end
+  
+  private
+  def sanitize(filename)
+    # Remove any character that aren't 0-9, A-Z, a-z, or -
+    filename.gsub(/[^0-9A-Z\\-]/i, '_')
+  end
 end
+

--- a/logstash-input-cloudhub.gemspec
+++ b/logstash-input-cloudhub.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-input-cloudhub'
-  s.version       = '0.1.0'
+  s.version       = '0.2.0'
   s.licenses      = ['Apache License (2.0)']
   s.summary       = ''
   s.description   = ''


### PR DESCRIPTION
Now the plugin can fetch the logs of all application within an organization automatically.
Additional changes:
- flatten log output (less configuration in filter)
- stop faster on termination signal
- fetch size configurable
- sincedb moved from $HOME to data/plugins/cloudhub
- error hangling (automatic retry for some API errors)